### PR TITLE
Add wstunnel debug level and external template support

### DIFF
--- a/interlink/templates/virtual-kubelet-config.yaml
+++ b/interlink/templates/virtual-kubelet-config.yaml
@@ -73,6 +73,7 @@ data:
       TunnelImage: {{.Values.virtualNode.network.tunnelImage | default "ghcr.io/erebe/wstunnel:latest" | quote}}
       WildcardDNS: {{.Values.virtualNode.network.wildcardDNS | default "" | quote}}
       WstunnelTemplatePath: {{.Values.virtualNode.network.wstunnelTemplatePath | default "/etc/templates/wstunnel.yaml" | quote}}
+      WstunnelDebugLevel: {{.Values.virtualNode.network.wstunnelDebugLevel | default "DEBUG" | quote}}
       WstunnelCommand: {{ .Values.virtualNode.network.wstunnelCommand | quote }}
       {{- if .Values.virtualNode.network.fullMesh }}
       FullMesh: {{ .Values.virtualNode.network.fullMesh }}
@@ -130,7 +131,7 @@ data:
     {{- end }}
 {{- end }}
 ---
-{{- if .Values.virtualNode.network.enableTunnel }}
+{{- if and .Values.virtualNode.network.enableTunnel (not .Values.virtualNode.network.useExternalConfigMap) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -138,7 +139,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
 data:
   wstunnel.yaml: |
-{{- if .Values.virtualNode.network.customTemplate }}
+{{- if .Values.virtualNode.network.externalTemplate }}
+{{ .Files.Get .Values.virtualNode.network.externalTemplate | indent 4 }}
+{{- else if .Values.virtualNode.network.customTemplate }}
 {{ .Values.virtualNode.network.customTemplate | indent 4 }}
 {{- else if eq .Values.virtualNode.network.templateType "nginx" }}
 {{ .Files.Get "wstunnel-template_nginx.yaml" | indent 4 }}

--- a/interlink/templates/virtual-kubelet.yaml
+++ b/interlink/templates/virtual-kubelet.yaml
@@ -258,7 +258,11 @@ spec:
       {{- if .Values.virtualNode.network.enableTunnel }}
       - name: wstunnel-template
         configMap:
+          {{- if .Values.virtualNode.network.useExternalConfigMap }}
+          name: {{ .Values.virtualNode.network.externalTemplate }}
+          {{- else }}
           name: {{.Values.nodeName}}-wstunnel-template
+          {{- end }}
       {{- end }}
       
 

--- a/interlink/values.yaml
+++ b/interlink/values.yaml
@@ -107,6 +107,14 @@ virtualNode:
     templateType: ""
     # Custom wstunnel template content (optional, overrides templateType if set)
     customTemplate: ""
+    # External template reference (overrides customTemplate and templateType if set)
+    # Can be a local file path (e.g., "wstunnel-template_custom.yaml") or ConfigMap name
+    externalTemplate: ""
+    # Use existing ConfigMap for template instead of creating one
+    # If set to true, externalTemplate is treated as ConfigMap name
+    useExternalConfigMap: false
+    # Wstunnel debug level (e.g., "DEBUG", "INFO", "WARN", "ERROR")
+    wstunnelDebugLevel: "DEBUG"
     wstunnelCommand: |
       curl -L https://github.com/erebe/wstunnel/releases/download/v10.4.4/wstunnel_10.4.4_linux_amd64.tar.gz -o wstunnel.tar.gz && tar -xzvf wstunnel.tar.gz && chmod +x wstunnel && ./wstunnel client --http-upgrade-path-prefix %s %s ws://%s:80 &
 

--- a/interlink/wstunnel-template_nginx.yaml
+++ b/interlink/wstunnel-template_nginx.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - args:
-        - ./wstunnel server --log-lvl DEBUG --dns-resolver-prefer-ipv4 --restrict-http-upgrade-path-prefix {{.RandomPassword}}  ws://0.0.0.0:28080
+        - ./wstunnel server --log-lvl {{.WstunnelDebugLevel}} --dns-resolver-prefer-ipv4 --restrict-http-upgrade-path-prefix {{.RandomPassword}}  ws://0.0.0.0:28080
         command:
         - bash
         - -c

--- a/interlink/wstunnel-template_traefik.yaml
+++ b/interlink/wstunnel-template_traefik.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - args:
-        - ./wstunnel server --log-lvl DEBUG --dns-resolver-prefer-ipv4 --restrict-http-upgrade-path-prefix {{.RandomPassword}}  ws://0.0.0.0:28080
+        - ./wstunnel server --log-lvl {{.WstunnelDebugLevel}} --dns-resolver-prefer-ipv4 --restrict-http-upgrade-path-prefix {{.RandomPassword}}  ws://0.0.0.0:28080
         command:
         - bash
         - -c


### PR DESCRIPTION
Introduces new configuration options for wstunnel:

1. Debug Level Control:
   - Added wstunnelDebugLevel flag in values.yaml (default: "DEBUG")
   - Supports standard log levels: DEBUG, INFO, WARN, ERROR
   - Updated wstunnel-template_nginx.yaml and wstunnel-template_traefik.yaml to use variable
   - Config passed through InterLinkConfig.yaml to wstunnel templates

2. External Template Reference:
   - Added externalTemplate flag to reference local files or ConfigMap names
   - Added useExternalConfigMap flag to use existing ConfigMap instead of creating one
   - Priority: externalTemplate > customTemplate > templateType > default

Usage examples:
- Set debug level: virtualNode.network.wstunnelDebugLevel: "INFO"
- Use local file: virtualNode.network.externalTemplate: "my-custom-template.yaml"
- Use ConfigMap: virtualNode.network.externalTemplate: "my-configmap" and useExternalConfigMap: true

<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

<!-- Describe in plain English what this PR does -->

---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
